### PR TITLE
Update getkirby/cms version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
   },
   "require": {
     "getkirby/composer-installer": "^1.1",
-    "getkirby/cms": "^3.0"
+    "getkirby/cms": "^3.0 || ^4.0 || ^5.0"
   }
 }


### PR DESCRIPTION
On https://plugins.getkirby.com/medienbaecker/autofavicon the plugin is shown as compatible with Kirby v4, while the constraints in composer.json are pinned to ^3.0. The plugin should work with v3–v5 without issues.

Suggested fix in composer.json:
"getkirby/cms": "^3.0 || ^4.0 || ^5.0"